### PR TITLE
Add Linux-based offset scanner implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/build/
+CMakeCache.txt
+cmake-build-*
+*.o
+*.obj
+*.pdb
+*.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.16)
+project(offset_scanner LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_executable(offset_scanner
+    src/main.cpp
+    src/Vector3.h
+    src/ProcessUtils.cpp
+    src/ProcessUtils.h
+    src/ProcessMemoryReader.cpp
+    src/ProcessMemoryReader.h
+    src/OffsetScanner.cpp
+    src/OffsetScanner.h
+)
+
+if(UNIX)
+    target_link_libraries(offset_scanner PRIVATE pthread)
+endif()

--- a/src/OffsetScanner.cpp
+++ b/src/OffsetScanner.cpp
@@ -1,0 +1,105 @@
+#include "OffsetScanner.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <unordered_set>
+
+namespace {
+constexpr size_t vectorSizeBytes = sizeof(float) * 3;
+constexpr size_t scanChunkSize = 64 * 1024;
+constexpr size_t chunkOverlap = vectorSizeBytes - sizeof(float);
+}
+
+OffsetScanner::OffsetScanner(pid_t pid, std::vector<MemoryRegion> moduleRegions, ProcessMemoryReader reader)
+    : pid_(pid), moduleRegions_(std::move(moduleRegions)), reader_(std::move(reader)) {
+    moduleBase_ = std::numeric_limits<uintptr_t>::max();
+    for (const auto &region : moduleRegions_) {
+        moduleBase_ = std::min(moduleBase_, region.start);
+    }
+    if (moduleBase_ == std::numeric_limits<uintptr_t>::max()) {
+        moduleBase_ = 0;
+    }
+}
+
+std::vector<CandidateOffset> OffsetScanner::findCandidates(const Vector3 &target, float tolerance, size_t maxCandidates) const {
+    std::vector<CandidateOffset> candidates;
+    std::vector<uint8_t> buffer;
+    std::unordered_set<uintptr_t> seenAddresses;
+    for (const auto &region : moduleRegions_) {
+        if (!region.isReadable()) {
+            continue;
+        }
+        uintptr_t current = region.start;
+        while (current < region.end) {
+            const size_t bytesRemaining = static_cast<size_t>(region.end - current);
+            const size_t bytesToRead = std::min(scanChunkSize, bytesRemaining);
+            buffer.resize(bytesToRead);
+            if (!reader_.read(current, buffer.data(), bytesToRead)) {
+                current += bytesToRead;
+                continue;
+            }
+            if (bytesToRead < vectorSizeBytes) {
+                break;
+            }
+            const size_t lastStart = bytesToRead - vectorSizeBytes;
+            for (size_t offset = 0; offset <= lastStart; offset += sizeof(float)) {
+                Vector3 vector{};
+                std::memcpy(&vector.x, buffer.data() + offset, sizeof(float));
+                std::memcpy(&vector.y, buffer.data() + offset + sizeof(float), sizeof(float));
+                std::memcpy(&vector.z, buffer.data() + offset + 2 * sizeof(float), sizeof(float));
+                if (!approximatelyEqual(vector, target, tolerance)) {
+                    continue;
+                }
+                const uintptr_t absoluteAddress = current + offset;
+                if (seenAddresses.insert(absoluteAddress).second) {
+                    candidates.push_back({absoluteAddress, static_cast<ptrdiff_t>(absoluteAddress - moduleBase_), vector});
+                    if (candidates.size() >= maxCandidates) {
+                        return candidates;
+                    }
+                }
+            }
+            if (bytesToRead == bytesRemaining) {
+                break;
+            }
+            uintptr_t next = current + bytesToRead;
+            if (chunkOverlap < bytesToRead) {
+                next -= chunkOverlap;
+            }
+            if (next <= current) {
+                next = current + bytesToRead;
+            }
+            current = next;
+        }
+    }
+    return candidates;
+}
+
+std::vector<CandidateOffset> OffsetScanner::verifyCandidates(const std::vector<CandidateOffset> &candidates, const Vector3 &expected, float tolerance) const {
+    std::vector<CandidateOffset> filtered;
+    filtered.reserve(candidates.size());
+    for (const auto &candidate : candidates) {
+        Vector3 currentVector;
+        if (!readVector(candidate.address, currentVector)) {
+            continue;
+        }
+        if (approximatelyEqual(currentVector, expected, tolerance)) {
+            CandidateOffset updated = candidate;
+            updated.value = currentVector;
+            filtered.push_back(updated);
+        }
+    }
+    return filtered;
+}
+
+bool OffsetScanner::readVector(uintptr_t address, Vector3 &out) const {
+    std::array<float, 3> values{};
+    if (!reader_.read(address, values.data(), sizeof(values))) {
+        return false;
+    }
+    out = Vector3{values[0], values[1], values[2]};
+    return true;
+}

--- a/src/OffsetScanner.h
+++ b/src/OffsetScanner.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "ProcessMemoryReader.h"
+#include "ProcessUtils.h"
+#include "Vector3.h"
+
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+struct CandidateOffset {
+    uintptr_t address{};
+    ptrdiff_t offsetFromModule{};
+    Vector3 value{};
+};
+
+class OffsetScanner {
+public:
+    OffsetScanner(pid_t pid, std::vector<MemoryRegion> moduleRegions, ProcessMemoryReader reader);
+
+    std::vector<CandidateOffset> findCandidates(const Vector3 &target, float tolerance, size_t maxCandidates = 256) const;
+    std::vector<CandidateOffset> verifyCandidates(const std::vector<CandidateOffset> &candidates, const Vector3 &expected, float tolerance) const;
+
+    uintptr_t moduleBase() const { return moduleBase_; }
+    const std::vector<MemoryRegion> &moduleRegions() const { return moduleRegions_; }
+
+private:
+    bool readVector(uintptr_t address, Vector3 &out) const;
+
+    pid_t pid_{};
+    std::vector<MemoryRegion> moduleRegions_;
+    uintptr_t moduleBase_{};
+    ProcessMemoryReader reader_;
+};

--- a/src/ProcessMemoryReader.cpp
+++ b/src/ProcessMemoryReader.cpp
@@ -1,0 +1,78 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include "ProcessMemoryReader.h"
+
+#include <cerrno>
+#include <cstring>
+#include <fcntl.h>
+#include <iostream>
+#include <string>
+#include <sys/uio.h>
+#include <unistd.h>
+
+namespace {
+
+int openProcessMemory(pid_t pid) {
+    const std::string path = "/proc/" + std::to_string(pid) + "/mem";
+    const int fd = ::open(path.c_str(), O_RDONLY);
+    return fd;
+}
+
+} // namespace
+
+ProcessMemoryReader::ProcessMemoryReader(pid_t pid)
+    : pid_(pid), memFd_(openProcessMemory(pid)) {}
+
+ProcessMemoryReader::~ProcessMemoryReader() {
+    if (memFd_ >= 0) {
+        ::close(memFd_);
+    }
+}
+
+ProcessMemoryReader::ProcessMemoryReader(ProcessMemoryReader &&other) noexcept
+    : pid_(other.pid_), memFd_(other.memFd_) {
+    other.memFd_ = -1;
+}
+
+ProcessMemoryReader &ProcessMemoryReader::operator=(ProcessMemoryReader &&other) noexcept {
+    if (this != &other) {
+        if (memFd_ >= 0) {
+            ::close(memFd_);
+        }
+        pid_ = other.pid_;
+        memFd_ = other.memFd_;
+        other.memFd_ = -1;
+    }
+    return *this;
+}
+
+bool ProcessMemoryReader::isValid() const {
+    return pid_ > 0;
+}
+
+bool ProcessMemoryReader::read(uintptr_t address, void *buffer, size_t size) const {
+    if (size == 0) {
+        return true;
+    }
+#if defined(__linux__)
+    struct iovec local{};
+    struct iovec remote{};
+    local.iov_base = buffer;
+    local.iov_len = size;
+    remote.iov_base = reinterpret_cast<void *>(address);
+    remote.iov_len = size;
+    const ssize_t bytesRead = ::process_vm_readv(pid_, &local, 1, &remote, 1, 0);
+    if (bytesRead == static_cast<ssize_t>(size)) {
+        return true;
+    }
+#endif
+    if (memFd_ >= 0) {
+        const off_t offset = static_cast<off_t>(address);
+        const ssize_t bytesRead = ::pread(memFd_, buffer, size, offset);
+        if (bytesRead == static_cast<ssize_t>(size)) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/ProcessMemoryReader.h
+++ b/src/ProcessMemoryReader.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <sys/types.h>
+
+class ProcessMemoryReader {
+public:
+    explicit ProcessMemoryReader(pid_t pid);
+    ~ProcessMemoryReader();
+
+    ProcessMemoryReader(const ProcessMemoryReader &) = delete;
+    ProcessMemoryReader &operator=(const ProcessMemoryReader &) = delete;
+
+    ProcessMemoryReader(ProcessMemoryReader &&) noexcept;
+    ProcessMemoryReader &operator=(ProcessMemoryReader &&) noexcept;
+
+    bool isValid() const;
+    bool read(uintptr_t address, void *buffer, size_t size) const;
+
+    template <typename T>
+    std::optional<T> readValue(uintptr_t address) const {
+        T value{};
+        if (!read(address, &value, sizeof(T))) {
+            return std::nullopt;
+        }
+        return value;
+    }
+
+    pid_t pid() const { return pid_; }
+
+private:
+    pid_t pid_;
+    int memFd_;
+};

--- a/src/ProcessUtils.cpp
+++ b/src/ProcessUtils.cpp
@@ -1,0 +1,122 @@
+#include "ProcessUtils.h"
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+namespace {
+
+bool isNumber(const std::string &text) {
+    return !text.empty() && std::all_of(text.begin(), text.end(), [](unsigned char ch) {
+        return std::isdigit(ch) != 0;
+    });
+}
+
+std::string trim(const std::string &value) {
+    const auto first = value.find_first_not_of(" \t\n\r");
+    if (first == std::string::npos) {
+        return {};
+    }
+    const auto last = value.find_last_not_of(" \t\n\r");
+    return value.substr(first, last - first + 1);
+}
+
+} // namespace
+
+namespace ProcessUtils {
+
+std::vector<ProcessInfo> listProcesses() {
+    std::vector<ProcessInfo> processes;
+    const std::filesystem::path procPath{"/proc"};
+    for (const auto &entry : std::filesystem::directory_iterator(procPath)) {
+        if (!entry.is_directory()) {
+            continue;
+        }
+        const std::string directoryName = entry.path().filename().string();
+        if (!isNumber(directoryName)) {
+            continue;
+        }
+        pid_t pid = static_cast<pid_t>(std::stol(directoryName));
+        std::ifstream commFile(entry.path() / "comm");
+        std::string processName;
+        if (commFile) {
+            std::getline(commFile, processName);
+        }
+        processes.push_back({pid, processName});
+    }
+    std::sort(processes.begin(), processes.end(), [](const ProcessInfo &lhs, const ProcessInfo &rhs) {
+        return lhs.pid < rhs.pid;
+    });
+    return processes;
+}
+
+std::optional<ProcessInfo> findProcessByName(const std::string &name) {
+    const auto processes = listProcesses();
+    auto it = std::find_if(processes.begin(), processes.end(), [&](const ProcessInfo &info) {
+        return info.name == name;
+    });
+    if (it == processes.end()) {
+        return std::nullopt;
+    }
+    return *it;
+}
+
+std::vector<MemoryRegion> listMemoryRegions(pid_t pid) {
+    std::vector<MemoryRegion> regions;
+    std::ifstream mapsFile("/proc/" + std::to_string(pid) + "/maps");
+    if (!mapsFile) {
+        return regions;
+    }
+    std::string line;
+    while (std::getline(mapsFile, line)) {
+        std::istringstream iss(line);
+        std::string addressRange;
+        MemoryRegion region;
+        std::string offset;
+        std::string device;
+        std::string inode;
+        std::string pathname;
+        if (!(iss >> addressRange >> region.permissions >> offset >> device >> inode)) {
+            continue;
+        }
+        std::getline(iss, pathname);
+        region.pathname = trim(pathname);
+        const auto dashPos = addressRange.find('-');
+        if (dashPos == std::string::npos) {
+            continue;
+        }
+        region.start = std::stoull(addressRange.substr(0, dashPos), nullptr, 16);
+        region.end = std::stoull(addressRange.substr(dashPos + 1), nullptr, 16);
+        regions.push_back(region);
+    }
+    return regions;
+}
+
+std::vector<MemoryRegion> findModuleRegions(pid_t pid, const std::string &moduleName) {
+    std::vector<MemoryRegion> matches;
+    const auto regions = listMemoryRegions(pid);
+    for (const auto &region : regions) {
+        if (!region.pathname.empty()) {
+            const auto namePos = region.pathname.find(moduleName);
+            if (namePos != std::string::npos) {
+                matches.push_back(region);
+            }
+        }
+    }
+    return matches;
+}
+
+std::string describeMemoryRegion(const MemoryRegion &region) {
+    std::ostringstream oss;
+    oss << "0x" << std::hex << region.start << "-0x" << region.end
+        << " " << region.permissions;
+    if (!region.pathname.empty()) {
+        oss << " " << region.pathname;
+    }
+    return oss.str();
+}
+
+} // namespace ProcessUtils

--- a/src/ProcessUtils.h
+++ b/src/ProcessUtils.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <sys/types.h>
+
+struct MemoryRegion {
+    uintptr_t start{};
+    uintptr_t end{};
+    std::string permissions;
+    std::string pathname;
+
+    size_t size() const { return static_cast<size_t>(end - start); }
+    bool isReadable() const { return !permissions.empty() && permissions[0] == 'r'; }
+    bool isWritable() const { return permissions.size() > 1 && permissions[1] == 'w'; }
+};
+
+struct ProcessInfo {
+    pid_t pid{};
+    std::string name;
+};
+
+namespace ProcessUtils {
+
+std::vector<ProcessInfo> listProcesses();
+std::optional<ProcessInfo> findProcessByName(const std::string &name);
+std::vector<MemoryRegion> listMemoryRegions(pid_t pid);
+std::vector<MemoryRegion> findModuleRegions(pid_t pid, const std::string &moduleName);
+std::string describeMemoryRegion(const MemoryRegion &region);
+
+}

--- a/src/Vector3.h
+++ b/src/Vector3.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <array>
+#include <cmath>
+#include <iomanip>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <vector>
+
+struct Vector3 {
+    float x{};
+    float y{};
+    float z{};
+
+    Vector3() = default;
+    Vector3(float x_, float y_, float z_) : x(x_), y(y_), z(z_) {}
+
+    std::array<float, 3> toArray() const {
+        return {x, y, z};
+    }
+
+    std::string toString(int precision = 3) const {
+        std::ostringstream oss;
+        oss << std::fixed << std::setprecision(precision)
+            << "(" << x << ", " << y << ", " << z << ")";
+        return oss.str();
+    }
+
+    static Vector3 parse(const std::string &text) {
+        Vector3 result;
+        char comma1 = 0;
+        char comma2 = 0;
+        std::istringstream iss(text);
+        if (!(iss >> result.x >> comma1 >> result.y >> comma2 >> result.z) || comma1 != ',' || comma2 != ',') {
+            throw std::invalid_argument("Vector3 must be in format x,y,z");
+        }
+        return result;
+    }
+};
+
+inline bool approximatelyEqual(float lhs, float rhs, float tolerance) {
+    return std::fabs(lhs - rhs) <= tolerance;
+}
+
+inline bool approximatelyEqual(const Vector3 &lhs, const Vector3 &rhs, float tolerance) {
+    return approximatelyEqual(lhs.x, rhs.x, tolerance) &&
+           approximatelyEqual(lhs.y, rhs.y, tolerance) &&
+           approximatelyEqual(lhs.z, rhs.z, tolerance);
+}
+
+inline std::string formatOffsets(const std::vector<uintptr_t> &offsets) {
+    std::ostringstream oss;
+    for (size_t i = 0; i < offsets.size(); ++i) {
+        oss << "0x" << std::hex << offsets[i];
+        if (i + 1 != offsets.size()) {
+            oss << " -> ";
+        }
+    }
+    return oss.str();
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,201 @@
+#include "OffsetScanner.h"
+#include "ProcessMemoryReader.h"
+#include "ProcessUtils.h"
+#include "Vector3.h"
+
+#include <array>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct Options {
+    std::string processName;
+    std::string moduleName;
+    Vector3 primary{};
+    Vector3 secondary{};
+    bool hasPrimary{false};
+    bool hasSecondary{false};
+    float tolerance{0.01f};
+    size_t maxResults{64};
+};
+
+void printUsage(const char *programName) {
+    std::cout << "Usage: " << programName << " --process <name> --module <module> --primary <x,y,z> [options]\n"
+              << "Options:\n"
+              << "  --process <name>       Target process name as listed in /proc/<pid>/comm\n"
+              << "  --module <module>     Module or binary name to constrain the scan\n"
+              << "  --primary <x,y,z>     Known position sample (floats)\n"
+              << "  --secondary <x,y,z>   Optional second sample for validation\n"
+              << "  --tolerance <value>   Comparison tolerance (default 0.01)\n"
+              << "  --max-results <n>     Maximum number of candidates to display (default 64)\n"
+              << std::endl;
+}
+
+bool parseVectorArgument(const std::string &argument, Vector3 &out, std::string &error) {
+    try {
+        out = Vector3::parse(argument);
+        return true;
+    } catch (const std::exception &ex) {
+        error = ex.what();
+        return false;
+    }
+}
+
+bool parseOptions(int argc, char **argv, Options &options, std::string &error) {
+    if (argc < 2) {
+        error = "not enough arguments";
+        return false;
+    }
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--process") {
+            if (i + 1 >= argc) {
+                error = "--process requires a value";
+                return false;
+            }
+            options.processName = argv[++i];
+        } else if (arg == "--module") {
+            if (i + 1 >= argc) {
+                error = "--module requires a value";
+                return false;
+            }
+            options.moduleName = argv[++i];
+        } else if (arg == "--primary") {
+            if (i + 1 >= argc) {
+                error = "--primary requires a value";
+                return false;
+            }
+            if (!parseVectorArgument(argv[++i], options.primary, error)) {
+                return false;
+            }
+            options.hasPrimary = true;
+        } else if (arg == "--secondary") {
+            if (i + 1 >= argc) {
+                error = "--secondary requires a value";
+                return false;
+            }
+            if (!parseVectorArgument(argv[++i], options.secondary, error)) {
+                return false;
+            }
+            options.hasSecondary = true;
+        } else if (arg == "--tolerance") {
+            if (i + 1 >= argc) {
+                error = "--tolerance requires a value";
+                return false;
+            }
+            options.tolerance = std::strtof(argv[++i], nullptr);
+        } else if (arg == "--max-results") {
+            if (i + 1 >= argc) {
+                error = "--max-results requires a value";
+                return false;
+            }
+            options.maxResults = static_cast<size_t>(std::strtoul(argv[++i], nullptr, 10));
+        } else if (arg == "--help" || arg == "-h") {
+            return false;
+        } else {
+            error = "unknown argument: " + arg;
+            return false;
+        }
+    }
+    if (options.processName.empty()) {
+        error = "missing --process";
+        return false;
+    }
+    if (options.moduleName.empty()) {
+        error = "missing --module";
+        return false;
+    }
+    if (!options.hasPrimary) {
+        error = "missing --primary";
+        return false;
+    }
+    return true;
+}
+
+std::string formatAddress(uintptr_t address) {
+    std::ostringstream oss;
+    oss << "0x" << std::hex << address;
+    return oss.str();
+}
+
+void printCandidate(const CandidateOffset &candidate) {
+    std::cout << "  address: " << formatAddress(candidate.address)
+              << " | module offset: 0x" << std::hex << candidate.offsetFromModule
+              << std::dec << " | value: " << candidate.value.toString(5)
+              << std::endl;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+    Options options;
+    std::string error;
+    if (!parseOptions(argc, argv, options, error)) {
+        if (!error.empty()) {
+            std::cerr << "Error: " << error << "\n";
+        }
+        printUsage(argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    auto processInfo = ProcessUtils::findProcessByName(options.processName);
+    if (!processInfo) {
+        std::cerr << "Process '" << options.processName << "' not found.\n";
+        return EXIT_FAILURE;
+    }
+
+    const auto moduleRegions = ProcessUtils::findModuleRegions(processInfo->pid, options.moduleName);
+    if (moduleRegions.empty()) {
+        std::cerr << "Module '" << options.moduleName << "' not found in process.\n";
+        return EXIT_FAILURE;
+    }
+
+    ProcessMemoryReader reader(processInfo->pid);
+    if (!reader.isValid()) {
+        std::cerr << "Failed to open target process memory. Root privileges may be required.\n";
+        return EXIT_FAILURE;
+    }
+
+    OffsetScanner scanner(processInfo->pid, moduleRegions, std::move(reader));
+
+    std::cout << "Scanning process '" << processInfo->name << "' (pid " << processInfo->pid << ")\n";
+    std::cout << "Module regions:" << std::endl;
+    for (const auto &region : moduleRegions) {
+        std::cout << "  " << ProcessUtils::describeMemoryRegion(region) << std::endl;
+    }
+
+    std::cout << "Searching for primary position " << options.primary.toString(5)
+              << " with tolerance " << options.tolerance << std::endl;
+    auto candidates = scanner.findCandidates(options.primary, options.tolerance, options.maxResults);
+    if (candidates.empty()) {
+        std::cout << "No matching candidates found in module." << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "Found " << candidates.size() << " candidate addresses." << std::endl;
+    if (options.hasSecondary) {
+        std::cout << "Validating using secondary sample " << options.secondary.toString(5) << std::endl;
+        candidates = scanner.verifyCandidates(candidates, options.secondary, options.tolerance);
+        if (candidates.empty()) {
+            std::cout << "No candidates survived the secondary validation." << std::endl;
+            return EXIT_FAILURE;
+        }
+        std::cout << "Remaining candidates after validation: " << candidates.size() << std::endl;
+    } else {
+        std::cout << "Provide --secondary to validate results after moving in-game." << std::endl;
+    }
+
+    std::cout << "Candidate offsets:" << std::endl;
+    for (const auto &candidate : candidates) {
+        printCandidate(candidate);
+    }
+
+    std::cout << "Use the module offset to access the position vector relative to the module base." << std::endl;
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary
- add a command line scanner that locates player position vectors from process memory dumps
- add process and memory utilities to enumerate /proc, inspect modules and read target memory
- configure a simple CMake build and ignore build outputs

## Testing
- cmake -S . -B build
- cmake --build build
